### PR TITLE
Unicode in table names

### DIFF
--- a/trans.py
+++ b/trans.py
@@ -174,7 +174,7 @@ def trans_codec(enc):
         return codecs.CodecInfo(encode, no_decode)
 #    else:
     try:
-        enc_name, table_name = enc.split('/', 1)
+        enc_name, table_name = enc.split(u'/', 1)
     except ValueError:
         return None
     if enc_name != 'trans':


### PR DESCRIPTION
Without this patch code like this won't work

``` python
mystring.encode(u'trans/Международные телеграммы')
```
